### PR TITLE
Fix clang 6 "-Wdelete-non-virtual-dtor" warnings

### DIFF
--- a/src/dropbox/async/AsyncLaunchEmptyResult.h
+++ b/src/dropbox/async/AsyncLaunchEmptyResult.h
@@ -30,6 +30,7 @@ namespace async{
 
         LaunchEmptyResult(){}
         LaunchEmptyResult(Tag v):m_tag(v){}
+        virtual ~LaunchEmptyResult(){}
 
         Tag tag()const{return m_tag;}
         ///This response indicates that the processing is asynchronous. The string is an id that can be used to obtain the status of the asynchronous job.

--- a/src/dropbox/async/AsyncLaunchResultBase.h
+++ b/src/dropbox/async/AsyncLaunchResultBase.h
@@ -31,6 +31,7 @@ namespace async{
 
         LaunchResultBase(){}
         LaunchResultBase(Tag v):m_tag(v){}
+        virtual ~LaunchResultBase(){}
 
         Tag tag()const{return m_tag;}
         ///This response indicates that the processing is asynchronous. The string is an id that can be used to obtain the status of the asynchronous job.

--- a/src/dropbox/async/AsyncPollArg.h
+++ b/src/dropbox/async/AsyncPollArg.h
@@ -22,6 +22,8 @@ namespace async{
 
         PollArg(const QString& arg){ m_async_job_id = arg; };
 
+        virtual ~PollArg(){};
+
     public:
             /**
                 Id of the asynchronous job. This is the value of a response

--- a/src/dropbox/async/AsyncPollEmptyResult.h
+++ b/src/dropbox/async/AsyncPollEmptyResult.h
@@ -30,6 +30,7 @@ namespace async{
 
         PollEmptyResult(){}
         PollEmptyResult(Tag v):m_tag(v){}
+        virtual ~PollEmptyResult(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/async/AsyncPollError.h
+++ b/src/dropbox/async/AsyncPollError.h
@@ -34,6 +34,7 @@ namespace async{
 
         PollError(){}
         PollError(Tag v):m_tag(v){}
+        virtual ~PollError(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/async/AsyncPollResultBase.h
+++ b/src/dropbox/async/AsyncPollResultBase.h
@@ -28,6 +28,7 @@ namespace async{
 
         PollResultBase(){}
         PollResultBase(Tag v):m_tag(v){}
+        virtual ~PollResultBase(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/auth/AuthAuthError.h
+++ b/src/dropbox/auth/AuthAuthError.h
@@ -35,6 +35,7 @@ namespace auth{
 
         AuthError(){}
         AuthError(Tag v):m_tag(v){}
+        virtual ~AuthError(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/auth/AuthRateLimitError.h
+++ b/src/dropbox/auth/AuthRateLimitError.h
@@ -28,6 +28,8 @@ namespace auth{
         m_retry_after(1)
         { m_reason = arg; };
 
+        virtual ~RateLimitError(){};
+
     public:
             /**
                 The reason why the app is being rate limited.

--- a/src/dropbox/auth/AuthRateLimitReason.h
+++ b/src/dropbox/auth/AuthRateLimitReason.h
@@ -30,6 +30,7 @@ namespace auth{
 
         RateLimitReason(){}
         RateLimitReason(Tag v):m_tag(v){}
+        virtual ~RateLimitReason(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/endpoint/ApiEndpoint.h
+++ b/src/dropbox/endpoint/ApiEndpoint.h
@@ -17,6 +17,7 @@ namespace dropboxQt{
 
     public:
         ApiEndpoint(ApiClient* c);
+        virtual ~ApiEndpoint(){}
         QString       lastRequestInfo()const{return m_last_request_info;}
         void          cancelAll();
         void          runEventsLoop()const;

--- a/src/dropbox/files/FilesAddPropertiesError.h
+++ b/src/dropbox/files/FilesAddPropertiesError.h
@@ -37,6 +37,7 @@ namespace files{
 
         AddPropertiesError(){}
         AddPropertiesError(Tag v):m_tag(v){}
+        virtual ~AddPropertiesError(){}
 
         Tag tag()const{return m_tag;}
         ///Property template does not exist for given identifier.

--- a/src/dropbox/files/FilesAlphaGetMetadataError.h
+++ b/src/dropbox/files/FilesAlphaGetMetadataError.h
@@ -24,6 +24,7 @@ namespace files{
 
         AlphaGetMetadataError(){}
         AlphaGetMetadataError(Tag v):m_tag(v){}
+        virtual ~AlphaGetMetadataError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesCommitInfo.h
+++ b/src/dropbox/files/FilesCommitInfo.h
@@ -42,6 +42,8 @@ namespace files{
         ,m_mute(false)
         { m_path = arg; };
 
+        virtual ~CommitInfo(){};
+
     public:
             /**
                 Path in the user's Dropbox to save the file.

--- a/src/dropbox/files/FilesCreateFolderArg.h
+++ b/src/dropbox/files/FilesCreateFolderArg.h
@@ -19,6 +19,8 @@ namespace files{
 
         CreateFolderArg(const QString& arg){ m_path = arg; };
 
+        virtual ~CreateFolderArg(){};
+
     public:
             /**
                 Path in the user's Dropbox to create.

--- a/src/dropbox/files/FilesCreateFolderError.h
+++ b/src/dropbox/files/FilesCreateFolderError.h
@@ -21,6 +21,7 @@ namespace files{
 
         CreateFolderError(){}
         CreateFolderError(Tag v):m_tag(v){}
+        virtual ~CreateFolderError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesDeleteArg.h
+++ b/src/dropbox/files/FilesDeleteArg.h
@@ -19,6 +19,8 @@ namespace files{
 
         DeleteArg(const QString& arg){ m_path = arg; };
 
+        virtual ~DeleteArg(){};
+
     public:
             /**
                 Path in the user's Dropbox to delete.

--- a/src/dropbox/files/FilesDeleteError.h
+++ b/src/dropbox/files/FilesDeleteError.h
@@ -26,6 +26,7 @@ namespace files{
 
         DeleteError(){}
         DeleteError(Tag v):m_tag(v){}
+        virtual ~DeleteError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesDimensions.h
+++ b/src/dropbox/files/FilesDimensions.h
@@ -22,6 +22,8 @@ namespace files{
 
         Dimensions(const int& arg){ m_height = arg; };
 
+        virtual ~Dimensions(){};
+
     public:
             /**
                 Height of the photo/video.

--- a/src/dropbox/files/FilesDownloadArg.h
+++ b/src/dropbox/files/FilesDownloadArg.h
@@ -20,6 +20,8 @@ namespace files{
 
         DownloadArg(const QString& arg){ m_path = arg; };
 
+        virtual ~DownloadArg(){};
+
     public:
             /**
                 The path of the file to download.

--- a/src/dropbox/files/FilesDownloadError.h
+++ b/src/dropbox/files/FilesDownloadError.h
@@ -23,6 +23,7 @@ namespace files{
 
         DownloadError(){}
         DownloadError(Tag v):m_tag(v){}
+        virtual ~DownloadError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesGetCopyReferenceArg.h
+++ b/src/dropbox/files/FilesGetCopyReferenceArg.h
@@ -20,6 +20,8 @@ namespace files{
 
         GetCopyReferenceArg(const QString& arg){ m_path = arg; };
 
+        virtual ~GetCopyReferenceArg(){};
+
     public:
             /**
                 The path to the file or folder you want to get a copy reference

--- a/src/dropbox/files/FilesGetCopyReferenceError.h
+++ b/src/dropbox/files/FilesGetCopyReferenceError.h
@@ -23,6 +23,7 @@ namespace files{
 
         GetCopyReferenceError(){}
         GetCopyReferenceError(Tag v):m_tag(v){}
+        virtual ~GetCopyReferenceError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesGetCopyReferenceResult.h
+++ b/src/dropbox/files/FilesGetCopyReferenceResult.h
@@ -24,6 +24,8 @@ namespace files{
 
         GetCopyReferenceResult(const Metadata& arg){ m_metadata = arg; };
 
+        virtual ~GetCopyReferenceResult(){};
+
     public:
             /**
                 Metadata of the file or folder.

--- a/src/dropbox/files/FilesGetMetadataArg.h
+++ b/src/dropbox/files/FilesGetMetadataArg.h
@@ -35,6 +35,8 @@ namespace files{
         ,m_include_has_explicit_shared_members(false)
         { m_path = arg; };
 
+        virtual ~GetMetadataArg(){};
+
     public:
             /**
                 The path of a file or folder on Dropbox.

--- a/src/dropbox/files/FilesGetMetadataError.h
+++ b/src/dropbox/files/FilesGetMetadataError.h
@@ -21,6 +21,7 @@ namespace files{
 
         GetMetadataError(){}
         GetMetadataError(Tag v):m_tag(v){}
+        virtual ~GetMetadataError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesGetTemporaryLinkArg.h
+++ b/src/dropbox/files/FilesGetTemporaryLinkArg.h
@@ -19,6 +19,8 @@ namespace files{
 
         GetTemporaryLinkArg(const QString& arg){ m_path = arg; };
 
+        virtual ~GetTemporaryLinkArg(){};
+
     public:
             /**
                 The path to the file you want a temporary link to.

--- a/src/dropbox/files/FilesGetTemporaryLinkError.h
+++ b/src/dropbox/files/FilesGetTemporaryLinkError.h
@@ -23,6 +23,7 @@ namespace files{
 
         GetTemporaryLinkError(){}
         GetTemporaryLinkError(Tag v):m_tag(v){}
+        virtual ~GetTemporaryLinkError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesGetTemporaryLinkResult.h
+++ b/src/dropbox/files/FilesGetTemporaryLinkResult.h
@@ -22,6 +22,8 @@ namespace files{
 
         GetTemporaryLinkResult(const FileMetadata& arg){ m_metadata = arg; };
 
+        virtual ~GetTemporaryLinkResult(){};
+
     public:
             /**
                 Metadata of the file.

--- a/src/dropbox/files/FilesGpsCoordinates.h
+++ b/src/dropbox/files/FilesGpsCoordinates.h
@@ -22,6 +22,8 @@ namespace files{
 
         GpsCoordinates(const float& arg){ m_latitude = arg; };
 
+        virtual ~GpsCoordinates(){};
+
     public:
             /**
                 Latitude of the GPS coordinates.

--- a/src/dropbox/files/FilesInvalidPropertyGroupError.h
+++ b/src/dropbox/files/FilesInvalidPropertyGroupError.h
@@ -37,6 +37,7 @@ namespace files{
 
         InvalidPropertyGroupError(){}
         InvalidPropertyGroupError(Tag v):m_tag(v){}
+        virtual ~InvalidPropertyGroupError(){}
 
         Tag tag()const{return m_tag;}
         ///Property template does not exist for given identifier.

--- a/src/dropbox/files/FilesListFolderArg.h
+++ b/src/dropbox/files/FilesListFolderArg.h
@@ -39,6 +39,8 @@ namespace files{
         ,m_include_has_explicit_shared_members(false)
         { m_path = arg; };
 
+        virtual ~ListFolderArg(){};
+
     public:
             /**
                 The path to the folder you want to see the contents of.

--- a/src/dropbox/files/FilesListFolderContinueArg.h
+++ b/src/dropbox/files/FilesListFolderContinueArg.h
@@ -20,6 +20,8 @@ namespace files{
 
         ListFolderContinueArg(const QString& arg){ m_cursor = arg; };
 
+        virtual ~ListFolderContinueArg(){};
+
     public:
             /**
                 The cursor returned by your last call to :meth:`list_folder` or

--- a/src/dropbox/files/FilesListFolderContinueError.h
+++ b/src/dropbox/files/FilesListFolderContinueError.h
@@ -29,6 +29,7 @@ namespace files{
 
         ListFolderContinueError(){}
         ListFolderContinueError(Tag v):m_tag(v){}
+        virtual ~ListFolderContinueError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesListFolderError.h
+++ b/src/dropbox/files/FilesListFolderError.h
@@ -23,6 +23,7 @@ namespace files{
 
         ListFolderError(){}
         ListFolderError(Tag v):m_tag(v){}
+        virtual ~ListFolderError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesListFolderGetLatestCursorResult.h
+++ b/src/dropbox/files/FilesListFolderGetLatestCursorResult.h
@@ -20,6 +20,8 @@ namespace files{
 
         ListFolderGetLatestCursorResult(const QString& arg){ m_cursor = arg; };
 
+        virtual ~ListFolderGetLatestCursorResult(){};
+
     public:
             /**
                 Pass the cursor into :meth:`list_folder_continue` to see what's

--- a/src/dropbox/files/FilesListFolderLongpollArg.h
+++ b/src/dropbox/files/FilesListFolderLongpollArg.h
@@ -31,6 +31,8 @@ namespace files{
         m_timeout(30)
         { m_cursor = arg; };
 
+        virtual ~ListFolderLongpollArg(){};
+
     public:
             /**
                 A cursor as returned by :meth:`list_folder` or

--- a/src/dropbox/files/FilesListFolderLongpollError.h
+++ b/src/dropbox/files/FilesListFolderLongpollError.h
@@ -26,6 +26,7 @@ namespace files{
 
         ListFolderLongpollError(){}
         ListFolderLongpollError(Tag v):m_tag(v){}
+        virtual ~ListFolderLongpollError(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/files/FilesListFolderLongpollResult.h
+++ b/src/dropbox/files/FilesListFolderLongpollResult.h
@@ -22,6 +22,8 @@ namespace files{
 
         ListFolderLongpollResult(const bool& arg){ m_changes = arg; };
 
+        virtual ~ListFolderLongpollResult(){};
+
     public:
             /**
                 Indicates whether new changes are available. If true, call

--- a/src/dropbox/files/FilesListFolderResult.h
+++ b/src/dropbox/files/FilesListFolderResult.h
@@ -22,7 +22,7 @@ namespace files{
 
     public:
         ListFolderResult(){};
-
+        virtual ~ListFolderResult(){};
 
     public:
             /**

--- a/src/dropbox/files/FilesListRevisionsArg.h
+++ b/src/dropbox/files/FilesListRevisionsArg.h
@@ -24,6 +24,8 @@ namespace files{
         m_limit(10)
         { m_path = arg; };
 
+        virtual ~ListRevisionsArg(){};
+
     public:
             /**
                 The path to the file you want to see the revisions of.

--- a/src/dropbox/files/FilesListRevisionsError.h
+++ b/src/dropbox/files/FilesListRevisionsError.h
@@ -23,6 +23,7 @@ namespace files{
 
         ListRevisionsError(){}
         ListRevisionsError(Tag v):m_tag(v){}
+        virtual ~ListRevisionsError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesListRevisionsResult.h
+++ b/src/dropbox/files/FilesListRevisionsResult.h
@@ -22,6 +22,8 @@ namespace files{
 
         ListRevisionsResult(const bool& arg){ m_is_deleted = arg; };
 
+        virtual ~ListRevisionsResult(){};
+
     public:
             /**
                 If the file is deleted.

--- a/src/dropbox/files/FilesLookUpPropertiesError.h
+++ b/src/dropbox/files/FilesLookUpPropertiesError.h
@@ -24,6 +24,7 @@ namespace files{
 
         LookUpPropertiesError(){}
         LookUpPropertiesError(Tag v):m_tag(v){}
+        virtual ~LookUpPropertiesError(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/files/FilesLookupError.h
+++ b/src/dropbox/files/FilesLookupError.h
@@ -40,6 +40,7 @@ namespace files{
 
         LookupError(){}
         LookupError(Tag v):m_tag(v){}
+        virtual ~LookupError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesMediaInfo.h
+++ b/src/dropbox/files/FilesMediaInfo.h
@@ -28,6 +28,7 @@ namespace files{
 
         MediaInfo(){}
         MediaInfo(Tag v):m_tag(v){}
+        virtual ~MediaInfo(){}
 
         Tag tag()const{return m_tag;}
         ///The metadata for the photo/video.

--- a/src/dropbox/files/FilesMediaMetadata.h
+++ b/src/dropbox/files/FilesMediaMetadata.h
@@ -25,6 +25,8 @@ namespace files{
 
         MediaMetadata(const Dimensions& arg){ m_dimensions = arg; };
 
+        virtual ~MediaMetadata(){};
+
     public:
             /**
                 Dimension of the photo/video.

--- a/src/dropbox/files/FilesMetadata.h
+++ b/src/dropbox/files/FilesMetadata.h
@@ -34,6 +34,8 @@ namespace files{
 
         Metadata(const QString& arg){ m_name = arg; };
 
+        virtual ~Metadata(){};
+
     public:
             /**
                 The last component of the path (including extension). This never

--- a/src/dropbox/files/FilesPreviewArg.h
+++ b/src/dropbox/files/FilesPreviewArg.h
@@ -20,6 +20,8 @@ namespace files{
 
         PreviewArg(const QString& arg){ m_path = arg; };
 
+        virtual ~PreviewArg(){};
+
     public:
             /**
                 The path of the file to preview.

--- a/src/dropbox/files/FilesPreviewError.h
+++ b/src/dropbox/files/FilesPreviewError.h
@@ -36,6 +36,7 @@ namespace files{
 
         PreviewError(){}
         PreviewError(Tag v):m_tag(v){}
+        virtual ~PreviewError(){}
 
         Tag tag()const{return m_tag;}
         ///An error occurs when downloading metadata for the file.

--- a/src/dropbox/files/FilesPropertiesError.h
+++ b/src/dropbox/files/FilesPropertiesError.h
@@ -28,6 +28,7 @@ namespace files{
 
         PropertiesError(){}
         PropertiesError(Tag v):m_tag(v){}
+        virtual ~PropertiesError(){}
 
         Tag tag()const{return m_tag;}
         ///Property template does not exist for given identifier.

--- a/src/dropbox/files/FilesPropertyGroupUpdate.h
+++ b/src/dropbox/files/FilesPropertyGroupUpdate.h
@@ -25,6 +25,8 @@ namespace files{
 
         PropertyGroupUpdate(const QString& arg){ m_template_id = arg; };
 
+        virtual ~PropertyGroupUpdate(){};
+
     public:
             /**
                 A unique identifier for a property template.

--- a/src/dropbox/files/FilesPropertyGroupWithPath.h
+++ b/src/dropbox/files/FilesPropertyGroupWithPath.h
@@ -22,6 +22,8 @@ namespace files{
 
         PropertyGroupWithPath(const QString& arg){ m_path = arg; };
 
+        virtual ~PropertyGroupWithPath(){};
+
     public:
             /**
                 A unique identifier for the file.

--- a/src/dropbox/files/FilesRelocationArg.h
+++ b/src/dropbox/files/FilesRelocationArg.h
@@ -20,6 +20,8 @@ namespace files{
 
         RelocationArg(const QString& arg){ m_from_path = arg; };
 
+        virtual ~RelocationArg(){};
+
     public:
             /**
                 Path in the user's Dropbox to be copied or moved.

--- a/src/dropbox/files/FilesRelocationError.h
+++ b/src/dropbox/files/FilesRelocationError.h
@@ -45,6 +45,7 @@ namespace files{
 
         RelocationError(){}
         RelocationError(Tag v):m_tag(v){}
+        virtual ~RelocationError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesRemovePropertiesArg.h
+++ b/src/dropbox/files/FilesRemovePropertiesArg.h
@@ -21,6 +21,8 @@ namespace files{
 
         RemovePropertiesArg(const QString& arg){ m_path = arg; };
 
+        virtual ~RemovePropertiesArg(){};
+
     public:
             /**
                 A unique identifier for the file.

--- a/src/dropbox/files/FilesRemovePropertiesError.h
+++ b/src/dropbox/files/FilesRemovePropertiesError.h
@@ -30,6 +30,7 @@ namespace files{
 
         RemovePropertiesError(){}
         RemovePropertiesError(Tag v):m_tag(v){}
+        virtual ~RemovePropertiesError(){}
 
         Tag tag()const{return m_tag;}
         ///Property template does not exist for given identifier.

--- a/src/dropbox/files/FilesRestoreArg.h
+++ b/src/dropbox/files/FilesRestoreArg.h
@@ -20,6 +20,8 @@ namespace files{
 
         RestoreArg(const QString& arg){ m_path = arg; };
 
+        virtual ~RestoreArg(){};
+
     public:
             /**
                 The path to the file you want to restore.

--- a/src/dropbox/files/FilesRestoreError.h
+++ b/src/dropbox/files/FilesRestoreError.h
@@ -36,6 +36,7 @@ namespace files{
 
         RestoreError(){}
         RestoreError(Tag v):m_tag(v){}
+        virtual ~RestoreError(){}
 
         Tag tag()const{return m_tag;}
         ///An error occurs when downloading metadata for the file.

--- a/src/dropbox/files/FilesSaveCopyReferenceArg.h
+++ b/src/dropbox/files/FilesSaveCopyReferenceArg.h
@@ -21,6 +21,8 @@ namespace files{
 
         SaveCopyReferenceArg(const QString& arg){ m_copy_reference = arg; };
 
+        virtual ~SaveCopyReferenceArg(){};
+
     public:
             /**
                 A copy reference returned by :meth:`copy_reference_get`.

--- a/src/dropbox/files/FilesSaveCopyReferenceError.h
+++ b/src/dropbox/files/FilesSaveCopyReferenceError.h
@@ -42,6 +42,7 @@ namespace files{
 
         SaveCopyReferenceError(){}
         SaveCopyReferenceError(Tag v):m_tag(v){}
+        virtual ~SaveCopyReferenceError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesSaveCopyReferenceResult.h
+++ b/src/dropbox/files/FilesSaveCopyReferenceResult.h
@@ -21,6 +21,8 @@ namespace files{
 
         SaveCopyReferenceResult(const Metadata& arg){ m_metadata = arg; };
 
+        virtual ~SaveCopyReferenceResult(){};
+
     public:
             /**
                 The metadata of the saved file or folder in the user's Dropbox.

--- a/src/dropbox/files/FilesSaveUrlArg.h
+++ b/src/dropbox/files/FilesSaveUrlArg.h
@@ -20,6 +20,8 @@ namespace files{
 
         SaveUrlArg(const QString& arg){ m_path = arg; };
 
+        virtual ~SaveUrlArg(){};
+
     public:
             /**
                 The path in Dropbox where the URL will be saved to.

--- a/src/dropbox/files/FilesSaveUrlError.h
+++ b/src/dropbox/files/FilesSaveUrlError.h
@@ -35,6 +35,7 @@ namespace files{
 
         SaveUrlError(){}
         SaveUrlError(Tag v):m_tag(v){}
+        virtual ~SaveUrlError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesSaveUrlJobStatus.h
+++ b/src/dropbox/files/FilesSaveUrlJobStatus.h
@@ -30,6 +30,7 @@ namespace files{
 
         SaveUrlJobStatus(){}
         SaveUrlJobStatus(Tag v):m_tag(v){}
+        virtual ~SaveUrlJobStatus(){}
 
         Tag tag()const{return m_tag;}
         ///Metadata of the file where the URL is saved to.

--- a/src/dropbox/files/FilesSaveUrlResult.h
+++ b/src/dropbox/files/FilesSaveUrlResult.h
@@ -27,6 +27,7 @@ namespace files{
 
         SaveUrlResult(){}
         SaveUrlResult(Tag v):m_tag(v){}
+        virtual ~SaveUrlResult(){}
 
         Tag tag()const{return m_tag;}
         ///This response indicates that the processing is asynchronous. The string is an id that can be used to obtain the status of the asynchronous job.

--- a/src/dropbox/files/FilesSearchArg.h
+++ b/src/dropbox/files/FilesSearchArg.h
@@ -39,6 +39,8 @@ namespace files{
         ,m_mode(SearchMode::SearchMode_FILENAME)
         { m_path = arg; };
 
+        virtual ~SearchArg(){};
+
     public:
             /**
                 The path in the user's Dropbox to search. Should probably be a

--- a/src/dropbox/files/FilesSearchError.h
+++ b/src/dropbox/files/FilesSearchError.h
@@ -23,6 +23,7 @@ namespace files{
 
         SearchError(){}
         SearchError(Tag v):m_tag(v){}
+        virtual ~SearchError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesSearchMatch.h
+++ b/src/dropbox/files/FilesSearchMatch.h
@@ -22,6 +22,8 @@ namespace files{
 
         SearchMatch(const SearchMatchType& arg){ m_match_type = arg; };
 
+        virtual ~SearchMatch(){};
+
     public:
             /**
                 The type of the match.

--- a/src/dropbox/files/FilesSearchMatchType.h
+++ b/src/dropbox/files/FilesSearchMatchType.h
@@ -32,6 +32,7 @@ namespace files{
 
         SearchMatchType(){}
         SearchMatchType(Tag v):m_tag(v){}
+        virtual ~SearchMatchType(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/files/FilesSearchMode.h
+++ b/src/dropbox/files/FilesSearchMode.h
@@ -30,6 +30,7 @@ namespace files{
 
         SearchMode(){}
         SearchMode(Tag v):m_tag(v){}
+        virtual ~SearchMode(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/files/FilesSearchResult.h
+++ b/src/dropbox/files/FilesSearchResult.h
@@ -25,6 +25,8 @@ namespace files{
 
         SearchResult(const std::list <SearchMatch>& arg){ m_matches = arg; };
 
+        virtual ~SearchResult(){};
+
     public:
             /**
                 A list (possibly empty) of matches for the query.

--- a/src/dropbox/files/FilesSharingInfo.h
+++ b/src/dropbox/files/FilesSharingInfo.h
@@ -22,6 +22,8 @@ namespace files{
 
         SharingInfo(const bool& arg){ m_read_only = arg; };
 
+        virtual ~SharingInfo(){};
+
     public:
             /**
                 True if the file or folder is inside a read-only shared folder.

--- a/src/dropbox/files/FilesThumbnailArg.h
+++ b/src/dropbox/files/FilesThumbnailArg.h
@@ -31,6 +31,8 @@ namespace files{
         ,m_size(ThumbnailSize::ThumbnailSize_W64H64)
         { m_path = arg; };
 
+        virtual ~ThumbnailArg(){};
+
     public:
             /**
                 The path to the image file you want to thumbnail.

--- a/src/dropbox/files/FilesThumbnailError.h
+++ b/src/dropbox/files/FilesThumbnailError.h
@@ -37,6 +37,7 @@ namespace files{
 
         ThumbnailError(){}
         ThumbnailError(Tag v):m_tag(v){}
+        virtual ~ThumbnailError(){}
 
         Tag tag()const{return m_tag;}
         ///An error occurs when downloading metadata for the image.

--- a/src/dropbox/files/FilesThumbnailFormat.h
+++ b/src/dropbox/files/FilesThumbnailFormat.h
@@ -22,6 +22,7 @@ namespace files{
 
         ThumbnailFormat(){}
         ThumbnailFormat(Tag v):m_tag(v){}
+        virtual ~ThumbnailFormat(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/files/FilesThumbnailSize.h
+++ b/src/dropbox/files/FilesThumbnailSize.h
@@ -35,6 +35,7 @@ namespace files{
 
         ThumbnailSize(){}
         ThumbnailSize(Tag v):m_tag(v){}
+        virtual ~ThumbnailSize(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/files/FilesUpdatePropertiesError.h
+++ b/src/dropbox/files/FilesUpdatePropertiesError.h
@@ -34,6 +34,7 @@ namespace files{
 
         UpdatePropertiesError(){}
         UpdatePropertiesError(Tag v):m_tag(v){}
+        virtual ~UpdatePropertiesError(){}
 
         Tag tag()const{return m_tag;}
         ///Property template does not exist for given identifier.

--- a/src/dropbox/files/FilesUpdatePropertyGroupArg.h
+++ b/src/dropbox/files/FilesUpdatePropertyGroupArg.h
@@ -22,6 +22,8 @@ namespace files{
 
         UpdatePropertyGroupArg(const QString& arg){ m_path = arg; };
 
+        virtual ~UpdatePropertyGroupArg(){};
+
     public:
             /**
                 A unique identifier for the file.

--- a/src/dropbox/files/FilesUploadError.h
+++ b/src/dropbox/files/FilesUploadError.h
@@ -26,6 +26,7 @@ namespace files{
 
         UploadError(){}
         UploadError(Tag v):m_tag(v){}
+        virtual ~UploadError(){}
 
         Tag tag()const{return m_tag;}
         ///Unable to save the uploaded contents to a file.

--- a/src/dropbox/files/FilesUploadErrorWithProperties.h
+++ b/src/dropbox/files/FilesUploadErrorWithProperties.h
@@ -26,6 +26,7 @@ namespace files{
 
         UploadErrorWithProperties(){}
         UploadErrorWithProperties(Tag v):m_tag(v){}
+        virtual ~UploadErrorWithProperties(){}
 
         Tag tag()const{return m_tag;}
         ///Unable to save the uploaded contents to a file.

--- a/src/dropbox/files/FilesUploadSessionAppendArg.h
+++ b/src/dropbox/files/FilesUploadSessionAppendArg.h
@@ -27,6 +27,8 @@ namespace files{
         m_close(false)
         { m_cursor = arg; };
 
+        virtual ~UploadSessionAppendArg(){};
+
     public:
             /**
                 Contains the upload session ID and the offset.

--- a/src/dropbox/files/FilesUploadSessionCursor.h
+++ b/src/dropbox/files/FilesUploadSessionCursor.h
@@ -23,6 +23,8 @@ namespace files{
 
         UploadSessionCursor(const QString& arg){ m_session_id = arg; };
 
+        virtual ~UploadSessionCursor(){};
+
     public:
             /**
                 The upload session ID (returned by

--- a/src/dropbox/files/FilesUploadSessionFinishArg.h
+++ b/src/dropbox/files/FilesUploadSessionFinishArg.h
@@ -23,6 +23,8 @@ namespace files{
 
         UploadSessionFinishArg(const UploadSessionCursor& arg){ m_cursor = arg; };
 
+        virtual ~UploadSessionFinishArg(){};
+
     public:
             /**
                 Contains the upload session ID and the offset.

--- a/src/dropbox/files/FilesUploadSessionFinishBatchArg.h
+++ b/src/dropbox/files/FilesUploadSessionFinishBatchArg.h
@@ -20,6 +20,8 @@ namespace files{
 
         UploadSessionFinishBatchArg(const std::list <UploadSessionFinishArg>& arg){ m_entries = arg; };
 
+        virtual ~UploadSessionFinishBatchArg(){};
+
     public:
             /**
                 Commit information for each file in the batch.

--- a/src/dropbox/files/FilesUploadSessionFinishBatchJobStatus.h
+++ b/src/dropbox/files/FilesUploadSessionFinishBatchJobStatus.h
@@ -28,6 +28,7 @@ namespace files{
 
         UploadSessionFinishBatchJobStatus(){}
         UploadSessionFinishBatchJobStatus(Tag v):m_tag(v){}
+        virtual ~UploadSessionFinishBatchJobStatus(){}
 
         Tag tag()const{return m_tag;}
         ///The :route:`upload_session/finish_batch` has finished.

--- a/src/dropbox/files/FilesUploadSessionFinishBatchResult.h
+++ b/src/dropbox/files/FilesUploadSessionFinishBatchResult.h
@@ -20,6 +20,8 @@ namespace files{
 
         UploadSessionFinishBatchResult(const std::list <UploadSessionFinishBatchResultEntry>& arg){ m_entries = arg; };
 
+        virtual ~UploadSessionFinishBatchResult(){};
+
     public:
             /**
                 Commit result for each file in the batch.

--- a/src/dropbox/files/FilesUploadSessionFinishBatchResultEntry.h
+++ b/src/dropbox/files/FilesUploadSessionFinishBatchResultEntry.h
@@ -24,6 +24,7 @@ namespace files{
 
         UploadSessionFinishBatchResultEntry(){}
         UploadSessionFinishBatchResultEntry(Tag v):m_tag(v){}
+        virtual ~UploadSessionFinishBatchResultEntry(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesUploadSessionFinishError.h
+++ b/src/dropbox/files/FilesUploadSessionFinishError.h
@@ -36,6 +36,7 @@ namespace files{
 
         UploadSessionFinishError(){}
         UploadSessionFinishError(Tag v):m_tag(v){}
+        virtual ~UploadSessionFinishError(){}
 
         Tag tag()const{return m_tag;}
         ///The session arguments are incorrect; the value explains the reason.

--- a/src/dropbox/files/FilesUploadSessionLookupError.h
+++ b/src/dropbox/files/FilesUploadSessionLookupError.h
@@ -41,6 +41,7 @@ namespace files{
 
         UploadSessionLookupError(){}
         UploadSessionLookupError(Tag v):m_tag(v){}
+        virtual ~UploadSessionLookupError(){}
 
         Tag tag()const{return m_tag;}
         ///The specified offset was incorrect. See the value for the correct offset. (This error may occur when a previous request was received and processed successfully but the client did not receive the response, e.g. due to a network error.)

--- a/src/dropbox/files/FilesUploadSessionOffsetError.h
+++ b/src/dropbox/files/FilesUploadSessionOffsetError.h
@@ -20,6 +20,8 @@ namespace files{
 
         UploadSessionOffsetError(const int& arg){ m_correct_offset = arg; };
 
+        virtual ~UploadSessionOffsetError(){};
+
     public:
             /**
                 The offset up to which data has been collected.

--- a/src/dropbox/files/FilesUploadSessionStartArg.h
+++ b/src/dropbox/files/FilesUploadSessionStartArg.h
@@ -25,6 +25,8 @@ namespace files{
         m_close(false)
         { m_close = arg; };
 
+        virtual ~UploadSessionStartArg(){};
+
     public:
             /**
                 If true, the current session will be closed, at which point you

--- a/src/dropbox/files/FilesUploadSessionStartResult.h
+++ b/src/dropbox/files/FilesUploadSessionStartResult.h
@@ -21,6 +21,8 @@ namespace files{
 
         UploadSessionStartResult(const QString& arg){ m_session_id = arg; };
 
+        virtual ~UploadSessionStartResult(){};
+
     public:
             /**
                 A unique identifier for the upload session. Pass this to

--- a/src/dropbox/files/FilesUploadWriteFailed.h
+++ b/src/dropbox/files/FilesUploadWriteFailed.h
@@ -22,6 +22,8 @@ namespace files{
 
         UploadWriteFailed(const WriteError& arg){ m_reason = arg; };
 
+        virtual ~UploadWriteFailed(){};
+
     public:
             /**
                 The reason why the file couldn't be saved.

--- a/src/dropbox/files/FilesWriteConflictError.h
+++ b/src/dropbox/files/FilesWriteConflictError.h
@@ -32,6 +32,7 @@ namespace files{
 
         WriteConflictError(){}
         WriteConflictError(Tag v):m_tag(v){}
+        virtual ~WriteConflictError(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/files/FilesWriteError.h
+++ b/src/dropbox/files/FilesWriteError.h
@@ -41,6 +41,7 @@ namespace files{
 
         WriteError(){}
         WriteError(Tag v):m_tag(v){}
+        virtual ~WriteError(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/files/FilesWriteMode.h
+++ b/src/dropbox/files/FilesWriteMode.h
@@ -46,6 +46,7 @@ namespace files{
 
         WriteMode(){}
         WriteMode(Tag v):m_tag(v){}
+        virtual ~WriteMode(){}
 
         Tag tag()const{return m_tag;}
         ///Overwrite if the given "rev" matches the existing file's "rev". The autorename strategy is to append the string "conflicted copy" to the file name. For example, "document.txt" might become "document (conflicted copy).txt" or "document (Panda's conflicted copy).txt".

--- a/src/dropbox/properties/PropertiesGetPropertyTemplateArg.h
+++ b/src/dropbox/properties/PropertiesGetPropertyTemplateArg.h
@@ -20,6 +20,8 @@ namespace properties{
 
         GetPropertyTemplateArg(const QString& arg){ m_template_id = arg; };
 
+        virtual ~GetPropertyTemplateArg(){};
+
     public:
             /**
                 An identifier for property template added by route

--- a/src/dropbox/properties/PropertiesListPropertyTemplateIds.h
+++ b/src/dropbox/properties/PropertiesListPropertyTemplateIds.h
@@ -20,6 +20,8 @@ namespace properties{
 
         ListPropertyTemplateIds(const std::list <QString>& arg){ m_template_ids = arg; };
 
+        virtual ~ListPropertyTemplateIds(){};
+
     public:
             /**
                 List of identifiers for templates added by route

--- a/src/dropbox/properties/PropertiesModifyPropertyTemplateError.h
+++ b/src/dropbox/properties/PropertiesModifyPropertyTemplateError.h
@@ -44,6 +44,7 @@ namespace properties{
 
         ModifyPropertyTemplateError(){}
         ModifyPropertyTemplateError(Tag v):m_tag(v){}
+        virtual ~ModifyPropertyTemplateError(){}
 
         Tag tag()const{return m_tag;}
         ///Property template does not exist for given identifier.

--- a/src/dropbox/properties/PropertiesPropertyField.h
+++ b/src/dropbox/properties/PropertiesPropertyField.h
@@ -22,6 +22,8 @@ namespace properties{
 
         PropertyField(const QString& arg){ m_name = arg; };
 
+        virtual ~PropertyField(){};
+
     public:
             /**
                 This is the name or key of a custom property in a property

--- a/src/dropbox/properties/PropertiesPropertyFieldTemplate.h
+++ b/src/dropbox/properties/PropertiesPropertyFieldTemplate.h
@@ -30,6 +30,8 @@ namespace properties{
 
         PropertyFieldTemplate(const QString& arg){ m_name = arg; };
 
+        virtual ~PropertyFieldTemplate(){};
+
     public:
             /**
                 This is the name or key of a custom property in a property

--- a/src/dropbox/properties/PropertiesPropertyGroup.h
+++ b/src/dropbox/properties/PropertiesPropertyGroup.h
@@ -25,6 +25,8 @@ namespace properties{
 
         PropertyGroup(const QString& arg){ m_template_id = arg; };
 
+        virtual ~PropertyGroup(){};
+
     public:
             /**
                 A unique identifier for a property template type.

--- a/src/dropbox/properties/PropertiesPropertyGroupTemplate.h
+++ b/src/dropbox/properties/PropertiesPropertyGroupTemplate.h
@@ -29,6 +29,8 @@ namespace properties{
 
         PropertyGroupTemplate(const QString& arg){ m_name = arg; };
 
+        virtual ~PropertyGroupTemplate(){};
+
     public:
             /**
                 A display name for the property template. Property template

--- a/src/dropbox/properties/PropertiesPropertyTemplateError.h
+++ b/src/dropbox/properties/PropertiesPropertyTemplateError.h
@@ -30,6 +30,7 @@ namespace properties{
 
         PropertyTemplateError(){}
         PropertyTemplateError(Tag v):m_tag(v){}
+        virtual ~PropertyTemplateError(){}
 
         Tag tag()const{return m_tag;}
         ///Property template does not exist for given identifier.

--- a/src/dropbox/properties/PropertiesPropertyType.h
+++ b/src/dropbox/properties/PropertiesPropertyType.h
@@ -29,6 +29,7 @@ namespace properties{
 
         PropertyType(){}
         PropertyType(Tag v):m_tag(v){}
+        virtual ~PropertyType(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/sharing/SharingAddMember.h
+++ b/src/dropbox/sharing/SharingAddMember.h
@@ -30,6 +30,8 @@ namespace sharing{
         m_access_level(AccessLevel::AccessLevel_VIEWER)
         { m_member = arg; };
 
+        virtual ~AddMember(){};
+
     public:
             /**
                 The member to add to the shared folder.

--- a/src/dropbox/sharing/SharingFileAction.h
+++ b/src/dropbox/sharing/SharingFileAction.h
@@ -48,6 +48,7 @@ namespace sharing{
 
         FileAction(){}
         FileAction(Tag v):m_tag(v){}
+        virtual ~FileAction(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/sharing/SharingFilePermission.h
+++ b/src/dropbox/sharing/SharingFilePermission.h
@@ -27,6 +27,8 @@ namespace sharing{
 
         FilePermission(const FileAction& arg){ m_action = arg; };
 
+        virtual ~FilePermission(){};
+
     public:
             /**
                 The action that the user may wish to take on the file.

--- a/src/dropbox/sharing/SharingFolderAction.h
+++ b/src/dropbox/sharing/SharingFolderAction.h
@@ -64,6 +64,7 @@ namespace sharing{
 
         FolderAction(){}
         FolderAction(Tag v):m_tag(v){}
+        virtual ~FolderAction(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/sharing/SharingFolderPermission.h
+++ b/src/dropbox/sharing/SharingFolderPermission.h
@@ -27,6 +27,8 @@ namespace sharing{
 
         FolderPermission(const FolderAction& arg){ m_action = arg; };
 
+        virtual ~FolderPermission(){};
+
     public:
             /**
                 The action that the user may wish to take on the folder.

--- a/src/dropbox/sharing/SharingLinkMetadata.h
+++ b/src/dropbox/sharing/SharingLinkMetadata.h
@@ -26,6 +26,8 @@ namespace sharing{
 
         LinkMetadata(const QString& arg){ m_url = arg; };
 
+        virtual ~LinkMetadata(){};
+
     public:
             /**
                 URL of the shared link.

--- a/src/dropbox/sharing/SharingMemberAction.h
+++ b/src/dropbox/sharing/SharingMemberAction.h
@@ -44,6 +44,7 @@ namespace sharing{
 
         MemberAction(){}
         MemberAction(Tag v):m_tag(v){}
+        virtual ~MemberAction(){}
 
         Tag tag()const{return m_tag;}
     public:

--- a/src/dropbox/sharing/SharingMemberPermission.h
+++ b/src/dropbox/sharing/SharingMemberPermission.h
@@ -28,6 +28,8 @@ namespace sharing{
 
         MemberPermission(const MemberAction& arg){ m_action = arg; };
 
+        virtual ~MemberPermission(){};
+
     public:
             /**
                 The action that the user may wish to take on the member.

--- a/src/dropbox/sharing/SharingMemberSelector.h
+++ b/src/dropbox/sharing/SharingMemberSelector.h
@@ -31,6 +31,7 @@ namespace sharing{
 
         MemberSelector(){}
         MemberSelector(Tag v):m_tag(v){}
+        virtual ~MemberSelector(){}
 
         Tag tag()const{return m_tag;}
         ///Dropbox account, team member, or group ID of member.

--- a/src/dropbox/sharing/SharingMembershipInfo.h
+++ b/src/dropbox/sharing/SharingMembershipInfo.h
@@ -33,6 +33,8 @@ namespace sharing{
         m_is_inherited(false)
         { m_access_type = arg; };
 
+        virtual ~MembershipInfo(){};
+
     public:
             /**
                 The access type for this member.

--- a/src/dropbox/sharing/SharingParentFolderAccessInfo.h
+++ b/src/dropbox/sharing/SharingParentFolderAccessInfo.h
@@ -26,6 +26,8 @@ namespace sharing{
 
         ParentFolderAccessInfo(const QString& arg){ m_folder_name = arg; };
 
+        virtual ~ParentFolderAccessInfo(){};
+
     public:
             /**
                 Display name for the folder.

--- a/src/dropbox/sharing/SharingSharedFileMetadata.h
+++ b/src/dropbox/sharing/SharingSharedFileMetadata.h
@@ -47,6 +47,8 @@ namespace sharing{
 
         SharedFileMetadata(const FolderPolicy& arg){ m_policy = arg; };
 
+        virtual ~SharedFileMetadata(){};
+
     public:
             /**
                 Policies governing this shared file.

--- a/src/dropbox/sharing/SharingSharedFolderMetadataBase.h
+++ b/src/dropbox/sharing/SharingSharedFolderMetadataBase.h
@@ -33,6 +33,8 @@ namespace sharing{
 
         SharedFolderMetadataBase(const AccessLevel& arg){ m_access_type = arg; };
 
+        virtual ~SharedFolderMetadataBase(){};
+
     public:
             /**
                 The current user's access level for this shared folder.

--- a/src/dropbox/sharing/SharingSharedLinkMetadata.h
+++ b/src/dropbox/sharing/SharingSharedLinkMetadata.h
@@ -40,6 +40,8 @@ namespace sharing{
 
         SharedLinkMetadata(const QString& arg){ m_url = arg; };
 
+        virtual ~SharedLinkMetadata(){};
+
     public:
             /**
                 URL of the shared link.

--- a/src/dropbox/team/TeamApiApp.h
+++ b/src/dropbox/team/TeamApiApp.h
@@ -27,6 +27,8 @@ namespace team{
 
         ApiApp(const QString& arg){ m_app_id = arg; };
 
+        virtual ~ApiApp(){};
+
     public:
             /**
                 The application unique id

--- a/src/dropbox/team/TeamDeviceSession.h
+++ b/src/dropbox/team/TeamDeviceSession.h
@@ -25,6 +25,8 @@ namespace team{
 
         DeviceSession(const QString& arg){ m_session_id = arg; };
 
+        virtual ~DeviceSession(){};
+
     public:
             /**
                 The session id

--- a/src/dropbox/team/TeamGroupMemberInfo.h
+++ b/src/dropbox/team/TeamGroupMemberInfo.h
@@ -24,6 +24,8 @@ namespace team{
 
         GroupMemberInfo(const MemberProfile& arg){ m_profile = arg; };
 
+        virtual ~GroupMemberInfo(){};
+
     public:
             /**
                 Profile of group member.

--- a/src/dropbox/team/TeamMemberAccess.h
+++ b/src/dropbox/team/TeamMemberAccess.h
@@ -24,6 +24,8 @@ namespace team{
 
         MemberAccess(const UserSelectorArg& arg){ m_user = arg; };
 
+        virtual ~MemberAccess(){};
+
     public:
             /**
                 Identity of a user.

--- a/src/dropbox/team/TeamMemberAddArg.h
+++ b/src/dropbox/team/TeamMemberAddArg.h
@@ -33,6 +33,8 @@ namespace team{
         ,m_role(AdminTier::AdminTier_MEMBER_ONLY)
         { m_member_email = arg; };
 
+        virtual ~MemberAddArg(){};
+
     public:
         QString memberEmail()const{return m_member_email;};
         MemberAddArg& setMemberemail(const QString& arg){m_member_email=arg;return *this;};

--- a/src/dropbox/team/TeamMemberAddResult.h
+++ b/src/dropbox/team/TeamMemberAddResult.h
@@ -64,6 +64,7 @@ namespace team{
 
         MemberAddResult(){}
         MemberAddResult(Tag v):m_tag(v){}
+        virtual ~MemberAddResult(){}
 
         Tag tag()const{return m_tag;}
         ///Describes a user that was successfully added to the team.

--- a/src/dropbox/team/TeamMemberDevices.h
+++ b/src/dropbox/team/TeamMemberDevices.h
@@ -27,6 +27,8 @@ namespace team{
 
         MemberDevices(const QString& arg){ m_team_member_id = arg; };
 
+        virtual ~MemberDevices(){};
+
     public:
             /**
                 The member unique Id

--- a/src/dropbox/team/TeamMemberLinkedApps.h
+++ b/src/dropbox/team/TeamMemberLinkedApps.h
@@ -24,6 +24,8 @@ namespace team{
 
         MemberLinkedApps(const QString& arg){ m_team_member_id = arg; };
 
+        virtual ~MemberLinkedApps(){};
+
     public:
             /**
                 The member unique Id

--- a/src/dropbox/team/TeamRevokeDeviceSessionArg.h
+++ b/src/dropbox/team/TeamRevokeDeviceSessionArg.h
@@ -31,6 +31,7 @@ namespace team{
 
         RevokeDeviceSessionArg(){}
         RevokeDeviceSessionArg(Tag v):m_tag(v){}
+        virtual ~RevokeDeviceSessionArg(){};
 
         Tag tag()const{return m_tag;}
         ///End an active session

--- a/src/dropbox/team/TeamRevokeDeviceSessionStatus.h
+++ b/src/dropbox/team/TeamRevokeDeviceSessionStatus.h
@@ -21,6 +21,8 @@ namespace team{
 
         RevokeDeviceSessionStatus(const bool& arg){ m_success = arg; };
 
+        virtual ~RevokeDeviceSessionStatus(){};
+
     public:
             /**
                 Result of the revoking request

--- a/src/dropbox/team/TeamRevokeLinkedApiAppArg.h
+++ b/src/dropbox/team/TeamRevokeLinkedApiAppArg.h
@@ -26,6 +26,8 @@ namespace team{
         m_keep_app_folder(false)
         { m_app_id = arg; };
 
+        virtual ~RevokeLinkedApiAppArg(){};
+
     public:
             /**
                 The application's unique id

--- a/src/dropbox/team/TeamRevokeLinkedAppStatus.h
+++ b/src/dropbox/team/TeamRevokeLinkedAppStatus.h
@@ -21,6 +21,8 @@ namespace team{
 
         RevokeLinkedAppStatus(const bool& arg){ m_success = arg; };
 
+        virtual ~RevokeLinkedAppStatus(){};
+
     public:
             /**
                 Result of the revoking request

--- a/src/dropbox/team/TeamStorageBucket.h
+++ b/src/dropbox/team/TeamStorageBucket.h
@@ -24,6 +24,8 @@ namespace team{
 
         StorageBucket(const QString& arg){ m_bucket = arg; };
 
+        virtual ~StorageBucket(){};
+
     public:
             /**
                 The name of the storage bucket. For example, '1G' is a bucket of

--- a/src/dropbox/team/TeamTeamMemberInfo.h
+++ b/src/dropbox/team/TeamTeamMemberInfo.h
@@ -24,6 +24,8 @@ namespace team{
 
         TeamMemberInfo(const TeamMemberProfile& arg){ m_profile = arg; };
 
+        virtual ~TeamMemberInfo(){};
+
     public:
             /**
                 Profile of a user as a member of a team.

--- a/src/dropbox/team/TeamUserSelectorArg.h
+++ b/src/dropbox/team/TeamUserSelectorArg.h
@@ -28,6 +28,7 @@ namespace team{
 
         UserSelectorArg(){}
         UserSelectorArg(Tag v):m_tag(v){}
+        virtual ~UserSelectorArg(){}
 
         Tag tag()const{return m_tag;}
         ///None

--- a/src/dropbox/team_common/TeamCommonGroupSummary.h
+++ b/src/dropbox/team_common/TeamCommonGroupSummary.h
@@ -25,6 +25,8 @@ namespace team_common{
 
         GroupSummary(const QString& arg){ m_group_name = arg; };
 
+        virtual ~GroupSummary(){};
+
     public:
         QString groupName()const{return m_group_name;};
         GroupSummary& setGroupname(const QString& arg){m_group_name=arg;return *this;};


### PR DESCRIPTION
Clang 6 emits tons of these now when building with -Wall:

  warning: delete called on non-final 'dropboxQt::Endpoint' that has virtual
  functions but non-virtual destructor [-Wdelete-non-virtual-dtor]

This change adds empty virtual destructors in classes that have virtual
functions in order to get rid of the warnings.